### PR TITLE
feat: parent dashboard with progress and chatbot

### DIFF
--- a/apps/parent-dashboard/src/store.ts
+++ b/apps/parent-dashboard/src/store.ts
@@ -8,6 +8,7 @@ export type Challenge = { id: string; childId: string; domain: 'food' | 'math' |
 type State = {
   children: Child[];
   challenges: Challenge[];
+  progress: Record<string, number>;
   loading: boolean;
   createChild: (parentId: string, name: string, avatarStyle: string) => Promise<void>;
   createChallenge: (childId: string, domain: Challenge['domain'], title: string, goal: string) => Promise<void>;
@@ -17,6 +18,7 @@ type State = {
 export const useStore = create<State>((set, get) => ({
   children: [],
   challenges: [],
+  progress: {},
   loading: false,
   async createChild(parentId, name, avatarStyle) {
     set({ loading: true });
@@ -49,6 +51,17 @@ export const useStore = create<State>((set, get) => ({
       method: 'POST',
       headers: { 'content-type': 'application/json' },
       body: JSON.stringify({ childId, challengeId, type, value }),
+    });
+    set((state) => {
+      const current = state.progress[challengeId] || 0;
+      const progress = { ...state.progress, [challengeId]: current + value };
+      let challenges = state.challenges;
+      if (type === 'win') {
+        challenges = state.challenges.map((ch) =>
+          ch.id === challengeId ? { ...ch, status: 'completed' } : ch
+        );
+      }
+      return { progress, challenges };
     });
   },
 }));

--- a/apps/parent-dashboard/src/ui/App.tsx
+++ b/apps/parent-dashboard/src/ui/App.tsx
@@ -1,27 +1,34 @@
 import React, { useState } from 'react';
 import { useStore } from '../store';
+import { Chatbot } from './Chatbot';
 
 export function App() {
-  const [screen, setScreen] = useState<'home' | 'child' | 'create'>('home');
   const [selectedChildId, setSelectedChildId] = useState<string | null>(null);
+
   return (
-    <div style={{ fontFamily: 'system-ui', padding: 16 }}>
-      <h1>TinyWins — Parent Dashboard</h1>
-      <nav style={{ display: 'flex', gap: 8 }}>
-        <button onClick={() => setScreen('home')}>Home</button>
-        <button onClick={() => setScreen('create')}>Create Challenge</button>
-        {selectedChildId && <button onClick={() => setScreen('child')}>Child</button>}
-      </nav>
-      <hr />
-      {screen === 'home' && <Home onSelectChild={(id) => { setSelectedChildId(id); setScreen('child'); }} />}
-      {screen === 'child' && selectedChildId && <ChildView childId={selectedChildId} />}
-      {screen === 'create' && selectedChildId && <CreateChallenge childId={selectedChildId} onDone={() => setScreen('child')} />}
-      {screen === 'create' && !selectedChildId && <p>Select a child from Home first.</p>}
+    <div style={{ display: 'flex', fontFamily: 'system-ui' }}>
+      <div style={{ flex: 1, padding: 16 }}>
+        <h1>TinyWins — Parent Dashboard</h1>
+        <Home onSelectChild={setSelectedChildId} selectedChildId={selectedChildId} />
+        {selectedChildId && (
+          <>
+            <CurrentChallenges childId={selectedChildId} />
+            <PastWins childId={selectedChildId} />
+          </>
+        )}
+      </div>
+      <Chatbot childId={selectedChildId} />
     </div>
   );
 }
 
-function Home({ onSelectChild }: { onSelectChild: (id: string) => void }) {
+function Home({
+  onSelectChild,
+  selectedChildId,
+}: {
+  onSelectChild: (id: string) => void;
+  selectedChildId: string | null;
+}) {
   const { children, createChild, loading } = useStore();
   const [name, setName] = useState('Ada');
   const [parentId, setParentId] = useState(crypto.randomUUID());
@@ -32,7 +39,12 @@ function Home({ onSelectChild }: { onSelectChild: (id: string) => void }) {
       <ul>
         {children.map((c) => (
           <li key={c.id}>
-            <button onClick={() => onSelectChild(c.id)}>{c.name}</button>
+            <button
+              style={{ fontWeight: selectedChildId === c.id ? 'bold' : undefined }}
+              onClick={() => onSelectChild(c.id)}
+            >
+              {c.name}
+            </button>
           </li>
         ))}
       </ul>
@@ -41,50 +53,48 @@ function Home({ onSelectChild }: { onSelectChild: (id: string) => void }) {
         <input placeholder="Parent ID" value={parentId} onChange={(e) => setParentId(e.target.value)} />
         <input placeholder="Name" value={name} onChange={(e) => setName(e.target.value)} />
         <input placeholder="Avatar" value={avatar} onChange={(e) => setAvatar(e.target.value)} />
-        <button disabled={loading} onClick={() => createChild(parentId, name, avatar)}>Create</button>
+        <button disabled={loading} onClick={() => createChild(parentId, name, avatar)}>
+          Create
+        </button>
       </div>
     </div>
   );
 }
 
-function ChildView({ childId }: { childId: string }) {
-  const { challenges, logProgress } = useStore();
-  const list = challenges.filter((ch) => ch.childId === childId);
+function CurrentChallenges({ childId }: { childId: string }) {
+  const { challenges, progress, logProgress } = useStore();
+  const list = challenges.filter((ch) => ch.childId === childId && ch.status !== 'completed');
   return (
-    <div>
-      <h2>Child</h2>
-      {list.length === 0 && <p>No challenges yet.</p>}
+    <section>
+      <h2>Current Challenges</h2>
+      {list.length === 0 && <p>No current challenges.</p>}
       <ul>
         {list.map((ch) => (
           <li key={ch.id}>
-            <b>{ch.title}</b> — {ch.goal}{' '}
-            <button onClick={() => logProgress(childId, ch.id, 'win')}>Celebrate Win</button>
+            <b>{ch.title}</b> — {progress[ch.id] || 0} wins{' '}
+            <button onClick={() => logProgress(childId, ch.id, 'win')}>Log Win</button>
           </li>
         ))}
       </ul>
-    </div>
+    </section>
   );
 }
 
-function CreateChallenge({ childId, onDone }: { childId: string; onDone: () => void }) {
-  const { createChallenge } = useStore();
-  const [domain, setDomain] = useState<'food' | 'math' | 'behavior'>('math');
-  const [title, setTitle] = useState('Try subtraction');
-  const [goal, setGoal] = useState('Do one problem');
+function PastWins({ childId }: { childId: string }) {
+  const { challenges, progress } = useStore();
+  const list = challenges.filter((ch) => ch.childId === childId && ch.status === 'completed');
   return (
-    <div>
-      <h2>Create Challenge</h2>
-      <div style={{ display: 'flex', gap: 8 }}>
-        <select value={domain} onChange={(e) => setDomain(e.target.value as any)}>
-          <option value="food">food</option>
-          <option value="math">math</option>
-          <option value="behavior">behavior</option>
-        </select>
-        <input placeholder="Title" value={title} onChange={(e) => setTitle(e.target.value)} />
-        <input placeholder="Goal" value={goal} onChange={(e) => setGoal(e.target.value)} />
-        <button onClick={async () => { await createChallenge(childId, domain, title, goal); onDone(); }}>Create</button>
-      </div>
-    </div>
+    <section style={{ marginTop: 32 }}>
+      <h2>Past Wins</h2>
+      {list.length === 0 && <p>No wins yet.</p>}
+      <ul>
+        {list.map((ch) => (
+          <li key={ch.id}>
+            <b>{ch.title}</b> — {progress[ch.id] || 0} wins
+          </li>
+        ))}
+      </ul>
+    </section>
   );
 }
 

--- a/apps/parent-dashboard/src/ui/Chatbot.tsx
+++ b/apps/parent-dashboard/src/ui/Chatbot.tsx
@@ -1,0 +1,89 @@
+import React, { useState } from 'react';
+import { useStore } from '../store';
+
+export function Chatbot({ childId }: { childId: string | null }) {
+  const { createChallenge } = useStore();
+  const [messages, setMessages] = useState<{ from: 'user' | 'bot'; text: string }[]>([]);
+  const [input, setInput] = useState('');
+  const [creating, setCreating] = useState(false);
+  const [domain, setDomain] = useState<'food' | 'math' | 'behavior'>('math');
+  const [title, setTitle] = useState('');
+  const [goal, setGoal] = useState('');
+
+  const sendMessage = async () => {
+    const text = input.trim();
+    if (!text) return;
+    setMessages((m) => [...m, { from: 'user', text }]);
+    setInput('');
+    if (text.toLowerCase().includes('create') && text.toLowerCase().includes('challenge')) {
+      if (!childId) {
+        setMessages((m) => [...m, { from: 'bot', text: 'Select a child first.' }]);
+        return;
+      }
+      setCreating(true);
+      setMessages((m) => [...m, { from: 'bot', text: 'Enter challenge details below.' }]);
+    } else if (text.toLowerCase().includes('support')) {
+      setMessages((m) => [...m, { from: 'bot', text: 'Support is on the way!' }]);
+    } else {
+      setMessages((m) => [...m, { from: 'bot', text: "I'm here to help." }]);
+    }
+  };
+
+  const submitChallenge = async () => {
+    if (!childId) return;
+    await createChallenge(childId, domain, title || 'New Challenge', goal || 'Give it a try');
+    setCreating(false);
+    setTitle('');
+    setGoal('');
+    setMessages((m) => [...m, { from: 'bot', text: 'Challenge created!' }]);
+  };
+
+  return (
+    <div
+      style={{
+        width: 300,
+        borderLeft: '1px solid #ccc',
+        padding: 16,
+        display: 'flex',
+        flexDirection: 'column',
+        height: '100vh',
+        boxSizing: 'border-box',
+      }}
+    >
+      <h2>Chat</h2>
+      <div style={{ flex: 1, overflowY: 'auto', marginBottom: 8 }}>
+        {messages.map((m, i) => (
+          <div key={i} style={{ textAlign: m.from === 'user' ? 'right' : 'left' }}>
+            <p>
+              <b>{m.from === 'user' ? 'You' : 'Bot'}:</b> {m.text}
+            </p>
+          </div>
+        ))}
+        {creating && (
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
+            <select value={domain} onChange={(e) => setDomain(e.target.value as any)}>
+              <option value="food">food</option>
+              <option value="math">math</option>
+              <option value="behavior">behavior</option>
+            </select>
+            <input placeholder="Title" value={title} onChange={(e) => setTitle(e.target.value)} />
+            <input placeholder="Goal" value={goal} onChange={(e) => setGoal(e.target.value)} />
+            <button onClick={submitChallenge}>Create</button>
+          </div>
+        )}
+      </div>
+      <div style={{ display: 'flex', gap: 4 }}>
+        <input
+          style={{ flex: 1 }}
+          value={input}
+          onChange={(e) => setInput(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter') sendMessage();
+          }}
+        />
+        <button onClick={sendMessage}>Send</button>
+      </div>
+    </div>
+  );
+}
+


### PR DESCRIPTION
## Summary
- track challenge progress and completion in state
- add parent dashboard showing current challenges and past wins
- introduce chatbot sidebar to create challenges or ask for support

## Testing
- `pnpm lint` *(fails: eslint config missing in workspace packages)*
- `pnpm --filter @tinywins/parent-dashboard lint` *(fails: eslint config missing)*
- `pnpm install` *(fails: No matching version for solclientjs@^10.20.0)*

------
https://chatgpt.com/codex/tasks/task_e_68bc4f455ec48325948f5e41a7c1136b