### PR TITLE
fix: specify pnpm version for CI workflows

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -18,6 +18,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4
+        with:
+          version: 8
       - uses: actions/setup-node@v4
         with:
           node-version: 20

--- a/.github/workflows/worker-deploy.yml
+++ b/.github/workflows/worker-deploy.yml
@@ -16,6 +16,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4
+        with:
+          version: 8
       - uses: actions/setup-node@v4
         with:
           node-version: 20


### PR DESCRIPTION
## Summary
- specify pnpm version for pages and worker deploy workflows

## Testing
- `pnpm --version`
- `pnpm test` *(fails: No package.json found)*

------
https://chatgpt.com/codex/tasks/task_e_68bc58d9fe4883258bb2e6984190f1f1