### PR TITLE
feat: refresh parent dashboard layout

### DIFF
--- a/apps/parent-dashboard/src/ui/App.css
+++ b/apps/parent-dashboard/src/ui/App.css
@@ -1,0 +1,131 @@
+/* Basic layout styling for dashboard */
+.layout {
+  display: flex;
+  min-height: 100vh;
+  font-family: system-ui, sans-serif;
+  background: #f3f4f6;
+}
+
+.sidebar {
+  width: 72px;
+  background: #1f2937;
+  color: #9ca3af;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding-top: 16px;
+  gap: 24px;
+}
+.sidebar .logo {
+  font-size: 24px;
+  color: white;
+}
+.sidebar a {
+  text-decoration: none;
+  font-size: 20px;
+}
+.sidebar a:hover {
+  color: white;
+}
+
+.main {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+}
+
+.topbar {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 16px;
+  background: white;
+  border-bottom: 1px solid #e5e7eb;
+}
+.topbar h1 {
+  font-size: 20px;
+  margin: 0;
+}
+.avatar {
+  width: 32px;
+  height: 32px;
+  background: #d1d5db;
+  border-radius: 50%;
+}
+
+.content {
+  padding: 16px;
+  flex: 1;
+  overflow-y: auto;
+}
+
+.stats-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 16px;
+  margin-bottom: 16px;
+}
+
+.card {
+  background: white;
+  border-radius: 12px;
+  padding: 16px;
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.05);
+}
+
+.metric {
+  font-size: 32px;
+  font-weight: 600;
+}
+.muted {
+  color: #6b7280;
+  margin-top: 4px;
+}
+
+/* Chatbot styling */
+.chatbot-panel {
+  position: fixed;
+  bottom: 24px;
+  right: 24px;
+  width: 320px;
+  background: white;
+  border-radius: 12px;
+  box-shadow: 0 8px 16px rgba(0, 0, 0, 0.1);
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  max-height: 80vh;
+}
+.chatbot-header {
+  padding: 12px 16px;
+  border-bottom: 1px solid #e5e7eb;
+  display: flex;
+  gap: 8px;
+  align-items: center;
+  font-weight: 600;
+}
+.chatbot-messages {
+  flex: 1;
+  overflow-y: auto;
+  padding: 12px;
+  background: #f9fafb;
+}
+.chatbot-form {
+  padding: 12px;
+  border-top: 1px solid #e5e7eb;
+  display: flex;
+  gap: 8px;
+}
+.chatbot-form input {
+  flex: 1;
+  padding: 8px;
+  border: 1px solid #d1d5db;
+  border-radius: 8px;
+}
+.chatbot-form button {
+  background: #2563eb;
+  color: white;
+  border: none;
+  padding: 8px 12px;
+  border-radius: 8px;
+}

--- a/apps/parent-dashboard/src/ui/App.tsx
+++ b/apps/parent-dashboard/src/ui/App.tsx
@@ -1,23 +1,74 @@
 import React, { useState } from 'react';
 import { useStore } from '../store';
 import { Chatbot } from './Chatbot';
+import './App.css';
 
 export function App() {
   const [selectedChildId, setSelectedChildId] = useState<string | null>(null);
 
   return (
-    <div style={{ display: 'flex', fontFamily: 'system-ui' }}>
-      <div style={{ flex: 1, padding: 16 }}>
-        <h1>TinyWins — Parent Dashboard</h1>
-        <Home onSelectChild={setSelectedChildId} selectedChildId={selectedChildId} />
-        {selectedChildId && (
-          <>
-            <CurrentChallenges childId={selectedChildId} />
-            <PastWins childId={selectedChildId} />
-          </>
-        )}
+    <div className="layout">
+      <Sidebar />
+      <div className="main">
+        <Topbar />
+        <div className="content">
+          <Stats childId={selectedChildId} />
+          <div className="card">
+            <Home onSelectChild={setSelectedChildId} selectedChildId={selectedChildId} />
+          </div>
+          {selectedChildId && (
+            <>
+              <div className="card" style={{ marginTop: 16 }}>
+                <CurrentChallenges childId={selectedChildId} />
+              </div>
+              <div className="card" style={{ marginTop: 16 }}>
+                <PastWins childId={selectedChildId} />
+              </div>
+            </>
+          )}
+        </div>
       </div>
       <Chatbot childId={selectedChildId} />
+    </div>
+  );
+}
+
+function Sidebar() {
+  return (
+    <nav className="sidebar">
+      <div className="logo">✨</div>
+      <a href="#">🏠</a>
+      <a href="#">👩‍💻</a>
+      <a href="#">⚙️</a>
+    </nav>
+  );
+}
+
+function Topbar() {
+  return (
+    <header className="topbar">
+      <h1>TinyWins</h1>
+      <div className="avatar" />
+    </header>
+  );
+}
+
+function Stats({ childId }: { childId: string | null }) {
+  const { events, challenges } = useStore();
+  const wins = events.filter((e) => (!childId || e.childId === childId) && e.type === 'win').length;
+  const activeChallenges = challenges.filter(
+    (c) => (!childId || c.childId === childId) && c.status !== 'completed'
+  ).length;
+  return (
+    <div className="stats-grid">
+      <div className="card">
+        <div className="metric">{wins}</div>
+        <div className="muted">Wins</div>
+      </div>
+      <div className="card">
+        <div className="metric">{activeChallenges}</div>
+        <div className="muted">Active Challenges</div>
+      </div>
     </div>
   );
 }

--- a/apps/parent-dashboard/src/ui/Chatbot.tsx
+++ b/apps/parent-dashboard/src/ui/Chatbot.tsx
@@ -83,13 +83,13 @@ export function Chatbot({ childId }: { childId: string | null }) {
   }
 
   return (
-    <aside style={{ width: 360, borderLeft: '1px solid #eee', display: 'flex', flexDirection: 'column', height: '100vh' }}>
-      <div style={{ padding: 12, borderBottom: '1px solid #eee', display: 'flex', gap: 8 }}>
-        <strong>Assistant</strong>
-        <button onClick={() => onSuggest('new')}>New Challenge</button>
-        <button onClick={() => onSuggest('support')}>Support Tips</button>
+    <div className="chatbot-panel">
+      <div className="chatbot-header">
+        <span>Assistant</span>
+        <button onClick={() => onSuggest('new')}>New</button>
+        <button onClick={() => onSuggest('support')}>Tips</button>
       </div>
-      <div style={{ flex: 1, overflowY: 'auto', padding: 12 }}>
+      <div className="chatbot-messages">
         {messages.map((m) => (
           <div key={m.id} style={{ margin: '8px 0' }}>
             {m.type === 'text' && (
@@ -117,16 +117,15 @@ export function Chatbot({ childId }: { childId: string | null }) {
         ))}
         <div ref={endRef} />
       </div>
-      <form onSubmit={handleSubmit} style={{ padding: 12, borderTop: '1px solid #eee', display: 'flex', gap: 8 }}>
+      <form onSubmit={handleSubmit} className="chatbot-form">
         <input
           value={input}
           onChange={(e) => setInput(e.target.value)}
           placeholder="Type a message…"
-          style={{ flex: 1, padding: 8 }}
         />
         <button type="submit">Send</button>
       </form>
-    </aside>
+    </div>
   );
 }
 


### PR DESCRIPTION
## Summary
- add sidebar, top bar, and stats cards to parent dashboard
- restyle chatbot as floating assistant panel
- add basic CSS for layout and chatbot

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: ESLint couldn't find a configuration file)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bc5e91e3c88325a1114a4010a26d9f